### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,4 @@ Properties :
 
 * *changeLogFile* specifies the entry point xml changelog file for liquibase.
 * *rollbackVersion* specifies the rollback version that will be used to apply a tag after successful changelog update.
+* *rollbackVersionPrefix* specifies the prefix added to the tag. Default is 'v'. The tag is composed as follows: <rollbackVersionPrefix><rollbackVersion>, for example: "v1" or "abc-1".

--- a/src/main/resources/liquibase/rule.py
+++ b/src/main/resources/liquibase/rule.py
@@ -18,10 +18,10 @@ def apply_changelog_steps(d, ctx):
                         script='liquibase/apply_changelog.py',
                         jython_context={"container": d.container, "deployed": d})
     ctx.addStep(step)
-    step = steps.jython(description="Create deployment rollback tag [v%s] in liquibase [%s]" % (d.rollbackVersion, d.container.name),
+    step = steps.jython(description="Create deployment rollback tag [%s%s] in liquibase [%s]" % (d.rollbackVersionPrefix, d.rollbackVersion, d.container.name),
                         order=CREATE_RESOURCES,
                         script='liquibase/apply_tag.py',
-                        jython_context={"container": d.container, "tag": "v%s" % d.rollbackVersion})
+                        jython_context={"container": d.container, "tag": "%s%s" % (d.rollbackVersionPrefix, d.rollbackVersion)})
     ctx.addStep(step)
 
 
@@ -43,10 +43,10 @@ def handle_destroy(d, ctx):
 
 def handle_modify(pd, d, ctx):
     if d.rollbackVersion < pd.rollbackVersion:
-        step = steps.jython(description="Rollback to tag [v%s] in liquibase [%s]" % (d.rollbackVersion, d.container.name),
+        step = steps.jython(description="Rollback to tag [%s%s] in liquibase [%s]" % (d.rollbackVersionPrefix, d.rollbackVersion, d.container.name),
                             order=DESTROY_RESOURCES,
                             script='liquibase/apply_rollback.py',
-                            jython_context={"container": d.container, "tag": "v%s" % d.rollbackVersion, "deployed": pd})
+                            jython_context={"container": d.container, "tag": "%s%s" % (d.rollbackVersionPrefix, d.rollbackVersion), "deployed": pd})
         ctx.addStep(step)
     else:
         apply_changelog_steps(d, ctx)

--- a/src/main/resources/synthetic.xml
+++ b/src/main/resources/synthetic.xml
@@ -17,6 +17,7 @@
 		<generate-deployable type="liquibase.Changelog" extends="udm.BaseDeployableFolderArtifact" />
 		<property name="changeLogFile"/>
 		<property name="rollbackVersion" kind="integer"/>
+		<property name="rollbackVersionPrefix" kind="string" required="false" default="v" description="Prefix added to rollback tag. Default value 'v'"/>
 		<property name="baseRollbackTag" default="xld_liquibase_base_version" hidden="true"/>
     </type>
 


### PR DESCRIPTION
Make it possible to add a custom prefix to the changeset tag. This gives you more control over the tag composition and the ability to apply changesets from different sources to the same database schema. Resolves #9.